### PR TITLE
Fix FFTW_NTHREADS to use num_threads instead of num_cores

### DIFF
--- a/src/QSM.jl
+++ b/src/QSM.jl
@@ -68,7 +68,7 @@ end
 ##### FFTW.jl
 #####
 
-const FFTW_NTHREADS = Ref{Int}(known(num_cores()))
+const FFTW_NTHREADS = Ref{Int}(nthreads())
 
 @static if FFTW.fftw_provider == "fftw"
     # modified `FFTW.spawnloop` to use Polyester for multi-threading

--- a/src/QSM.jl
+++ b/src/QSM.jl
@@ -68,7 +68,7 @@ end
 ##### FFTW.jl
 #####
 
-const FFTW_NTHREADS = Ref{Int}(nthreads())
+const FFTW_NTHREADS = Ref{Int}(min(nthreads(), known(num_cores())))
 
 @static if FFTW.fftw_provider == "fftw"
     # modified `FFTW.spawnloop` to use Polyester for multi-threading


### PR DESCRIPTION
I'm using a cluster system (PBS), and after submitting a job that includes calls to QSM.jl code, some jobs get automatically killed for using more CPUs than allocated to the job. Specifically, this has occurred with pdf.jl, which was killed for using 2.6 CPUs when only 2 were assigned.

This pull request changes the value of `const FFTW_NTHREADS` in QSM.jl from `num_cores()` to `nthreads()`, which for me seems to resolve the problem. 

Please let me know if this is not the right way to achieve this. Otherwise, hopefully, we can merge or tweak this change. 