### PR TITLE
Increment NIfTI dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QSM"
 uuid = "794fc106-2fa4-440f-961c-0d7d7b47016a"
 authors = ["kamesy <ckames@physics.ubc.ca>"]
-version = "0.5.3"
+version = "0.5.4"
 
 [deps]
 CPUSummary = "2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"
@@ -30,7 +30,7 @@ FastPow = "0.1.0"
 IrrationalConstants = "0.2.2"
 LinearMaps = "3.6.1"
 MacroTools = "0.5.6"
-NIfTI = "0.5.9"
+NIfTI = "0.6.0"
 Polyester = "0.7.0"
 PolyesterWeave = "0.2.1"
 SLEEFPirates = "0.6.38"


### PR DESCRIPTION
This is a very simple PR, only incrementing the NIfTI dependency.

Thank you very much for implementing this fast QSM package in julia!

Background for this PR:
There was an update of NIfTI.jl that fixes working with some datatypes. My package depends on both QSM.jl and NIfTI.jl, so it would be awesome if you could merge this change and release a new version ;)